### PR TITLE
Change to allow large value of ecmaVersion

### DIFF
--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -283,13 +283,11 @@ function normalizeEcmaVersion(
     espree: ESPree,
     version: number | "latest" | undefined,
 ) {
+    const latestEcmaVersion = getLatestEcmaVersion(espree)
     if (version == null || version === "latest") {
-        return getLatestEcmaVersion(espree)
+        return latestEcmaVersion
     }
-    if (version > 5 && version < 2015) {
-        return version + 2009
-    }
-    return version
+    return Math.min(getEcmaVersionYear(version), latestEcmaVersion)
 }
 
 /**
@@ -307,5 +305,12 @@ function getLatestEcmaVersion(espree: ESPree): number {
         }
         return 2018
     }
-    return normalizeEcmaVersion(espree, espree.latestEcmaVersion)
+    return getEcmaVersionYear(espree.latestEcmaVersion)
+}
+
+/**
+ * Get ECMAScript version year
+ */
+function getEcmaVersionYear(version: number) {
+    return version > 5 && version < 2015 ? version + 2009 : version
 }

--- a/tests/src/parser/parser-options.ts
+++ b/tests/src/parser/parser-options.ts
@@ -12,6 +12,13 @@ describe("Parser options.", () => {
             },
             errors: [],
         },
+        {
+            code: "1_2_3",
+            parserOptions: {
+                ecmaVersion: 2099,
+            },
+            errors: [],
+        },
     ]) {
         it(`${JSON.stringify(code)} with parserOptions: ${JSON.stringify(
             parserOptions,


### PR DESCRIPTION
Change the parser to use latestEcmaVersion if ecmaVersion is set to a value greater than latestEcmaVersion.

close #82