### PR TITLE
Added eslint peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,5 +79,8 @@
         "eslint-visitor-keys": "^3.0.0",
         "espree": "^9.0.0",
         "semver": "^7.3.5"
+    },
+    "peerDependencies": {
+        "eslint": ">=5"
     }
 }


### PR DESCRIPTION
Added `eslint` peerDependency in order to get rid of:
```
jsonc-eslint-parser@npm:2.0.4 doesn't provide eslint (pab279), requested by eslint-utils
```
warning.