### PR TITLE
fix: improve type compatibility with eslint

### DIFF
--- a/.changeset/sour-memes-happen.md
+++ b/.changeset/sour-memes-happen.md
@@ -1,0 +1,5 @@
+---
+"jsonc-eslint-parser": patch
+---
+
+improve type compatibility with eslint

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,8 @@ export interface JSONParserOptions {
   jsonSyntax?: JSONSyntax;
 }
 
-export type RuleFunction<Node extends AST.JSONNode = never> = (
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- used for compatibility with ESLint types
+export type RuleFunction<Node extends AST.JSONNode = any> = (
   node: Node,
 ) => void;
 


### PR DESCRIPTION
This change adjusts the `RuleFunction` generic type to default to `any` for the Node, instead of `never`.

Fixes #225 