### PR TITLE
fix: eslint

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(npx eslint:*)"
-    ],
-    "deny": [],
-    "ask": []
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ dist
 /lib
 /dist-ts
 /index.d.ts
+
+# Agents
+.claude


### PR DESCRIPTION
The repo had an ESLint warning, which I assume is a bug. This PR fixes it.

As a side note, I think that having ESLint warnings at all is [not ideal, as described by the legendary Josh Goldberg](https://www.joshuakgoldberg.com/blog/if-i-wrote-a-linter-part-2-developer-experience/#only-errors). Specifically, I see that the rule is being turned on [here](https://github.com/ota-meshi/eslint-plugin/blob/master/src/config-helpers/recommended.ts#L6). Assuming that Josh's blog is convincing to you, would you like me to do a PR to update your plugin and change all warns to errors?