### PR TITLE
refactor: replace semver with verkit

### DIFF
--- a/.changeset/warm-bikes-ask.md
+++ b/.changeset/warm-bikes-ask.md
@@ -1,0 +1,5 @@
+---
+"jsonc-eslint-parser": minor
+---
+
+refactor: replace semver with verkit

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "@types/estree": "^1.0.0",
     "@types/mocha": "^10.0.0",
     "@types/node": "^24.0.0",
-    "@types/semver": "^7.3.1",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "benchmark": "^2.1.4",
@@ -92,7 +91,7 @@
   "dependencies": {
     "acorn": "^8.5.0",
     "eslint-visitor-keys": "^5.0.0",
-    "semver": "^7.3.5"
+    "verkit": "^0.3.2"
   },
   "publishConfig": {
     "access": "public"

--- a/src/parser/modules/require-utils.ts
+++ b/src/parser/modules/require-utils.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
-import { lte } from "semver";
 import { createRequire } from "node:module";
+import { isLessOrEqual } from "verkit";
 
 /**
  * Get NodeJS.Require from Linter
@@ -90,7 +90,10 @@ export function loadNewest<T>(
   let target: { version: string; get: () => T | null } | null = null;
   for (const item of items) {
     const pkg = item.getPkg();
-    if (pkg != null && (!target || lte(target.version, pkg.version))) {
+    if (
+      pkg != null &&
+      (!target || isLessOrEqual(target.version, pkg.version))
+    ) {
       target = { version: pkg.version, get: item.get };
     }
   }

--- a/tests/src/parser/parser-options.ts
+++ b/tests/src/parser/parser-options.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import semver from "semver";
+import { satisfies } from "verkit";
 
 import * as jsoncParser from "../../../src/index.ts";
 import { Linter } from "eslint";
@@ -7,7 +7,7 @@ import espreePkg from "espree/package.json" with { type: "json" };
 
 describe("Parser options.", () => {
   for (const { code, parserOptions, errors } of [
-    ...(semver.satisfies(espreePkg.version, ">=7.2.0")
+    ...(satisfies(espreePkg.version, ">=7.2.0")
       ? [
           {
             code: "1_2_3",

--- a/tests/src/parser/parser.ts
+++ b/tests/src/parser/parser.ts
@@ -2,7 +2,7 @@
 import assert from "node:assert";
 import path from "node:path";
 import fs from "node:fs";
-import semver from "semver";
+import { satisfies } from "verkit";
 
 import { getStaticJSONValue, parseJSON } from "../../../src/index.ts";
 import { nodeReplacer } from "./utils.ts";
@@ -57,7 +57,7 @@ describe("Check for AST.", () => {
           pkgName === "node"
             ? process.version
             : require(`${pkgName}/package.json`).version;
-        return !semver.satisfies(version, pkgVersion as string);
+        return !satisfies(version, pkgVersion as string);
       })
     ) {
       continue;

--- a/tests/src/parser/syntaxes/json.ts
+++ b/tests/src/parser/syntaxes/json.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert";
-import semver from "semver";
+import { satisfies } from "verkit";
 
 import { parseForESLint } from "../../../../src/parser/parser.ts";
 import type { ParseError } from "../../../../src/parser/errors.ts";
@@ -50,7 +50,7 @@ describe("Check that parsing error is correct for JSON.", () => {
       index: 13,
       char: "/",
     },
-    ...(semver.satisfies(espreePkg.version, ">=7.2.0")
+    ...(satisfies(espreePkg.version, ">=7.2.0")
       ? [
           {
             code: '{"foo": 1_2_3}',


### PR DESCRIPTION
https://github.com/sxzz/verkit is a SemVer toolkit for modern ESM and TypeScript projects. It follows [node-semver](https://github.com/npm/node-semver) semantics while providing a functional, tree-shakeable API.

See also https://github.com/e18e/ecosystem-issues/issues/277