### PR TITLE
fix: remove unnecessary type assertions

### DIFF
--- a/src/parser/convert.ts
+++ b/src/parser/convert.ts
@@ -202,7 +202,7 @@ export function convertProgramNode(
         column: endLoc.column,
       },
     },
-    parent: null as never,
+    parent: null,
   };
   setParent(body, nn);
   return nn;

--- a/tests/src/parser/parser-options.ts
+++ b/tests/src/parser/parser-options.ts
@@ -37,7 +37,7 @@ describe("Parser options.", () => {
           files: ["*.json"],
           languageOptions: {
             parser: jsoncParser,
-            parserOptions: parserOptions as never,
+            parserOptions,
           },
         },
         "test.json",

--- a/tests/src/utils/ast.ts
+++ b/tests/src/utils/ast.ts
@@ -64,12 +64,12 @@ describe("isExpression", () => {
     "`template`",
   ]) {
     it(code, () => {
-      const ast: JSONProgram = parse(code).ast as never;
+      const ast: JSONProgram = parse(code).ast;
       assert.ok(isExpression(ast.body[0].expression));
     });
   }
   it("property is not expression", () => {
-    const ast: JSONProgram = parse("{a: 1}").ast as never;
+    const ast: JSONProgram = parse("{a: 1}").ast;
     assert.ok(
       !isExpression(
         (ast.body[0].expression as JSONObjectExpression).properties[0],
@@ -77,7 +77,7 @@ describe("isExpression", () => {
     );
   });
   it("property literal key is not expression", () => {
-    const ast: JSONProgram = parse('{"a": 1}').ast as never;
+    const ast: JSONProgram = parse('{"a": 1}').ast;
     assert.ok(
       !isExpression(
         (ast.body[0].expression as JSONObjectExpression).properties[0].key,
@@ -85,7 +85,7 @@ describe("isExpression", () => {
     );
   });
   it("property key is not expression", () => {
-    const ast: JSONProgram = parse("{a: 1}").ast as never;
+    const ast: JSONProgram = parse("{a: 1}").ast;
     assert.ok(
       !isExpression(
         (ast.body[0].expression as JSONObjectExpression).properties[0].key,
@@ -158,7 +158,7 @@ describe("getStaticJSONValue", () => {
     }
   });
   it("Error on property key", () => {
-    const ast: JSONProgram = parse("{a: 1}").ast as never;
+    const ast: JSONProgram = parse("{a: 1}").ast;
     try {
       getStaticJSONValue(
         (ast.body[0].expression as JSONObjectExpression).properties[0]


### PR DESCRIPTION
The CI lint job for #300 and its merge commit fails because `@typescript-eslint/no-unnecessary-type-assertion` reports seven redundant `as never` assertions in parser construction and tests.

This removes only those assertions. The existing declared and inferred types accept the values directly, so runtime behavior remains unchanged and CI can proceed to the build step.
