### PR TITLE
fix: restore .mjs extension for build output

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   entry: "src/index.ts",
   outDir: "lib",
   dts: true,
+  fixedExtension: true,
   platform: "neutral",
   deps: {
     dts: {


### PR DESCRIPTION
#304 dropped `format: "esm"` from the tsdown config, which changed the build output from `lib/index.mjs` / `lib/index.d.mts` to `lib/index.js` / `lib/index.d.ts`. The `exports` field in package.json and the explorer's import still point to the `.mjs` paths, so the GHPages deploy fails (https://github.com/ota-meshi/jsonc-eslint-parser/actions/runs/31230133165) and a package published in this state would have a broken `exports` field.

This adds `fixedExtension: true` so tsdown emits `.mjs` / `.d.mts` again, matching the existing references.