### PR TITLE
fix: migrate the release workflow to Changesets v2 inputs

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -42,10 +42,10 @@ jobs:
         uses: changesets/action@v2.0.0
         with:
           # this expects you to have a npm script called version that runs some logic and then calls `changeset version`.
-          version: npm run version:ci
+          version-script: npm run version:ci
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
-          publish: npm run release
-          commit: "chore: release jsonc-eslint-parser"
-          title: "chore: release jsonc-eslint-parser"
+          publish-script: npm run release
+          commit-message: "chore: release jsonc-eslint-parser"
+          pr-title: "chore: release jsonc-eslint-parser"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The upgrade to `changesets/action@v2.0.0` in #310 retained the v1 input names. Changesets v2 rejects those inputs before it can create a version pull request or publish a release, which caused the Release workflow to fail.

This renames the four affected inputs to `version-script`, `publish-script`, `commit-message`, and `pr-title` while preserving the existing commands and release metadata.
